### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "run"

--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Add new icon paths with the desired ID in the `src/assets/icons.svg` file.
 
 ## Usage
 Once everything is compiled and built the last step is to serve the contents of the `dist/` folder as static files with your web server of choice and you're done! 
+
+
+[![Run on Repl.it](https://repl.it/badge/github/nethruster/ptemplate)](https://repl.it/github/nethruster/ptemplate)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).